### PR TITLE
Especificacion de caso de uso : change green notes to green arrows in main flow

### DIFF
--- a/documentation/usecasesview/specifications/disciplines/AssignActitivy.puml
+++ b/documentation/usecasesview/specifications/disciplines/AssignActitivy.puml
@@ -1,4 +1,5 @@
 @startuml
+
     skinparam {
         NoteBackgroundColor #whiteSmoke
     }

--- a/documentation/usecasesview/specifications/disciplines/MergeActitivy.puml
+++ b/documentation/usecasesview/specifications/disciplines/MergeActitivy.puml
@@ -1,8 +1,10 @@
 @startuml
 
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
     state ITERATION_MANAGEMENT_STARTS as ":ITERATION_MANAGEMENT"
     state ITERATION_MANAGEMENT_ENDS as ":ITERATION_MANAGEMENT"
@@ -37,7 +39,7 @@ skinparam {
         User provides AssignedActivity
     end note
 
-    13 --> 20
+    13 -[#red]-> 20
     note on link
         User requests to cancel merge activity
     end note
@@ -53,7 +55,7 @@ skinparam {
     * cancel merge activity
     end note
 
-    14 --> 20
+    14 -[#red]-> 20
     note on link
         User requests to cancel merge activity
     end note
@@ -63,7 +65,7 @@ skinparam {
         User provides merge destination
     end note
 
-    20 --> [*]
+    20 -[#red]-> [*]
     note on link
          <b>System shows</b>
          * Merge activity cancelled

--- a/documentation/usecasesview/specifications/disciplines/OpenIteration.puml
+++ b/documentation/usecasesview/specifications/disciplines/OpenIteration.puml
@@ -1,8 +1,10 @@
 @startuml
 
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
 state 12 as ":PROJECT_MANAGEMENT"
 
@@ -48,7 +50,7 @@ state OpenIteration {
         * cancel
     end note
 
-    6 -down-> 11
+    6 -[#red]down-> 11
     note on link
         User requests to cancel
     end note
@@ -63,6 +65,7 @@ state OpenIteration {
     note on link
         User requests to confirm open iteration
     end note
+
     7 --> 9
     note on link
     [usecases introduced >= 1
@@ -78,7 +81,7 @@ state OpenIteration {
 
     7 --> 10
 
-    10 --> 4
+    10 -[#red]-> 4
     note on link
         <b>System shows</b>
         * more than one usecases should be introduced
@@ -91,7 +94,7 @@ state OpenIteration {
     end note
 
 }
-    11 -down-> 12
+    11 -[#red]down-> 12
     note on link
             <b>System shows</b>
             * operation cancelled
@@ -129,6 +132,6 @@ state OpenIteration {
 
     ITERATION_MANAGEMENT --> [*]
 
-    12 --> [*]
+    12 -[#red]-> [*]
 
 @enduml

--- a/documentation/usecasesview/specifications/disciplines/RestimateActitivy.puml
+++ b/documentation/usecasesview/specifications/disciplines/RestimateActitivy.puml
@@ -1,8 +1,10 @@
 @startuml
 
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
     state 5 as ":ITERATION_MANAGEMENT"
     state 13 as ":ITERATION_MANAGEMENT"
@@ -32,7 +34,7 @@ skinparam {
     * cancel re-estimate activity
     end note
 
-    2 --> 10
+    2 -[#red]-> 10
     note on link
         User requests to cancel re-estimate
     end note
@@ -55,7 +57,7 @@ skinparam {
         * cancel re-estimate
     end note
 
-    0 --> 10
+    0 -[#red]-> 10
     note on link
         User requests to cancel re-estimate
     end note
@@ -65,7 +67,7 @@ skinparam {
         User provides NotAssignedActivity duration
     end note
 
-    10 --> [*]
+    10 -[#red]-> [*]
     note on link
          <b>System shows</b>
          * re-estimate activity was cancelled

--- a/documentation/usecasesview/specifications/disciplines/SplitActitivy.puml
+++ b/documentation/usecasesview/specifications/disciplines/SplitActitivy.puml
@@ -1,8 +1,10 @@
 @startuml
 
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
 
     state ITERATION_MANAGEMENT_STARTS as ":ITERATION_MANAGEMENT"
@@ -34,7 +36,7 @@ skinparam {
     * cancel split activity
     end note
 
-    2 --> 10
+    2 -[#red]-> 10
     note on link
         User requests to cancel split
     end note
@@ -56,7 +58,7 @@ skinparam {
         * cancel split activity
     end note
 
-    0 --> 10
+    0 -[#red]-> 10
     note on link
         User requests to cancel split
     end note
@@ -76,7 +78,7 @@ skinparam {
         * 1 hour smaller "splitted" NotAssignedCost
     end note
 
-    10 --> [*]
+    10 -[#red]-> [*]
     note on link
          <b>System shows</b>
          * split activity was cancelled

--- a/documentation/usecasesview/specifications/general/CloseSystem.puml
+++ b/documentation/usecasesview/specifications/general/CloseSystem.puml
@@ -1,8 +1,10 @@
 @startuml
 
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
 state INIT_PROJECT as ":INIT_PROJECT"
 state PROJECT_MANAGEMENT as ":PROJECT_MANAGEMENT"

--- a/documentation/usecasesview/specifications/general/OpenIterations.puml
+++ b/documentation/usecasesview/specifications/general/OpenIterations.puml
@@ -1,7 +1,11 @@
 @startuml
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
+
+
     state PROJECT_MANAGEMENT as ":PROJECT_MANAGEMENT"
     state 2 as ":PROJECT_MANAGEMENT"
 

--- a/documentation/usecasesview/specifications/general/OpenPhases.puml
+++ b/documentation/usecasesview/specifications/general/OpenPhases.puml
@@ -1,7 +1,9 @@
 @startuml
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
     state PROJECT_MANAGEMENTSTART as ":PROJECT_MANAGEMENT"
     state PROJECT_MANAGEMENTEND as ":PROJECT_MANAGEMENT"

--- a/documentation/usecasesview/specifications/general/PlanProject.puml
+++ b/documentation/usecasesview/specifications/general/PlanProject.puml
@@ -1,8 +1,10 @@
 @startuml
 
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
 state PROJECT_MANAGEMENTEND as ":PROJECT_MANAGEMENT" #LawnGreen
 state INIT_PROJECTSTART as ":INIT_PROJECT"
@@ -35,14 +37,14 @@ state PlanProject {
     * cancel
     end note
 
-    2 --> 10
+    2 -[#red]-> 10
     note on link
         User requests to cancel
     end note
 
     2 --> 1
     note on link
-        User introduces
+        <b>User provides</b>
         * start date
         * end date
         * project cost
@@ -54,7 +56,7 @@ state PlanProject {
         User requests to confirm step
     end note
 
-    3 --> 1
+    3 -[#red]-> 1
     note on link
         [end date before start date
         OR start date after end date
@@ -80,12 +82,12 @@ state PlanProject {
         * cancel
     end note
 
-    5 --> 10
+    5 -[#red]-> 10
     note on link
         User requests to cancel
     end note
 
-    10 --> INIT_PROJECTEND
+    10 -[#red]-> INIT_PROJECTEND
     note on link
     <b>System allows</b>
     * plan project
@@ -94,7 +96,8 @@ state PlanProject {
 
     5 --> 4
     note on link
-        User introduces nº of iterations in project
+        <b>User provides</b>
+         * nº of iterations in project
     end note
 
     5 --> 6
@@ -117,7 +120,7 @@ state PlanProject {
           end note
 }
 
-INIT_PROJECTEND --> [*]
+INIT_PROJECTEND -[#red]-> [*]
 PROJECT_MANAGEMENTEND --> [*]
 
 

--- a/documentation/usecasesview/specifications/general/StartSystem.puml
+++ b/documentation/usecasesview/specifications/general/StartSystem.puml
@@ -1,9 +1,10 @@
 @startuml
 
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
-
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 state 4 as ":INIT_PROJECT"
 
 [*] --> StartSystem

--- a/documentation/usecasesview/specifications/members/CreateMember.puml
+++ b/documentation/usecasesview/specifications/members/CreateMember.puml
@@ -1,8 +1,10 @@
 @startuml
 
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
 state 6 as " :MEMBER_MANAGEMENT"
 
@@ -36,7 +38,7 @@ note on link
     * member roles
 end note
 
-1 --> 8
+1 -[#red]-> 8
 note on link
 User requests to cancel member creation
 end note
@@ -46,12 +48,12 @@ note on link
     User requests to confirm member creation
 end note
 
-4 --> 5
+4 -[#red]-> 5
 note on link
 [member name already exists]
 end note
 
-5 -left-> 1
+5 -[#red]left-> 1
 note on link
 <b>System shows</b>
 * member name already exists
@@ -65,7 +67,7 @@ note on link
     * member was created
 end note
 
-8 --> [*]
+8 -[#red]-> [*]
 note on link
     <b>System shows</b>
     * Operation cancelled

--- a/documentation/usecasesview/specifications/members/DeleteMember.puml
+++ b/documentation/usecasesview/specifications/members/DeleteMember.puml
@@ -1,5 +1,10 @@
 @startuml
-skinparam NoteBackgroundColor #whiteSmoke
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
+
 state init as "MEMBER_MANAGEMENT"
 state end as "MEMBER_MANAGEMENT"
 init ---> DeleteMemberUseCase
@@ -32,13 +37,13 @@ state DeleteMemberUseCase {
     * member
     end note
 
-    initial --> 6
+    initial -[#red]-> 6
     note on link
     <b>User requests</b>
     * to cancel
     end note
 
-    6 --> [*]
+    6 -[#red]-> [*]
     note on link
     <b>System shows</b>
     * operation cancelled

--- a/documentation/usecasesview/specifications/members/OpenMembers.puml
+++ b/documentation/usecasesview/specifications/members/OpenMembers.puml
@@ -1,7 +1,10 @@
 @startuml
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
+
 
     state 0 as ":PROJECT_MANAGEMENT"
     state 2 as ":USE_CASES_MANAGEMENT"

--- a/documentation/usecasesview/specifications/members/UpdateMember.puml
+++ b/documentation/usecasesview/specifications/members/UpdateMember.puml
@@ -3,9 +3,11 @@
 state 0 as " :MEMBER:MANAGEMENT"
 state 7 as " :MEMBER:MANAGEMENT"
 
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
 0 --> updateMember
 

--- a/documentation/usecasesview/specifications/usecases/CreateUseCase.puml
+++ b/documentation/usecasesview/specifications/usecases/CreateUseCase.puml
@@ -1,6 +1,9 @@
 @startuml
-skinparam NoteBackgroundColor #whiteSmoke
-
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
 'Initial/end states
 state init as "USE_CASE_MANAGEMENT"
@@ -71,25 +74,25 @@ state CreateUseCase {
            end note
 
     'variation path
-    editedUseCase --> errorValidation
+    editedUseCase -[#red]-> errorValidation
         note on link
         [ length(useCaseName) out of 5,25 ]
         end note
 
-    errorValidation --> createOrdered
+    errorValidation -[#red]-> createOrdered
             note on link
             <b>System shows</b>
             * The name length is not correct
             end note
 
     'variation path
-    requireToConfirm --> savedUseCase
+    requireToConfirm -[#red]-> savedUseCase
     note on link
           <b>User</b> cancel
     end note
 
     'variation path
-    editUseCase --> savedUseCase
+    editUseCase -[#red]-> savedUseCase
     note on link
           <b>User</b> cancel
     end note

--- a/documentation/usecasesview/specifications/usecases/DeleteUseCase.puml
+++ b/documentation/usecasesview/specifications/usecases/DeleteUseCase.puml
@@ -1,5 +1,9 @@
 @startuml
-skinparam NoteBackgroundColor #whiteSmoke
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
 state init as "USE_CASE_MANAGEMENT"
 state end as "USE_CASE_MANAGEMENT"
@@ -65,7 +69,7 @@ state DeleteUseCase {
     end note
 
     'Variation path
-    confirmationRequired --> showList
+    confirmationRequired -[#red]-> showList
     note on link
         <b>User request</b>
         * cancel

--- a/documentation/usecasesview/specifications/usecases/OpenUseCases.puml
+++ b/documentation/usecasesview/specifications/usecases/OpenUseCases.puml
@@ -1,8 +1,9 @@
 @startuml
-skinparam {
-    NoteBackgroundColor #whiteSmoke
-}
-
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
     state 0 as ":PROJECT_MANAGEMENT"
     state 2 as ":MEMBERS_MANAGEMENT"
     state 3 as ":DISCIPLINES_MANAGEMENT"

--- a/documentation/usecasesview/specifications/usecases/PrioritizeUseCases.puml
+++ b/documentation/usecasesview/specifications/usecases/PrioritizeUseCases.puml
@@ -1,19 +1,22 @@
 @startuml
-skinparam NoteBackgroundColor #whiteSmoke
-
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 state USECASE_MANAGEMENT_END as ":USECASE_MANAGEMENT"
 
 USECASE_MANAGEMENT --> prioritizeUseCases
 
 state prioritizeUseCases {
 
-state 1 as " " #LawnGreen
-state 2 as " " #LawnGreen
-state 8 as " " #LawnGreen
-state 9 as " " #LawnGreen
-state 10 as " " #LawnGreen
-state 11 as " " #LawnGreen
-state 12 as " " #LawnGreen
+state 1 as " "
+state 2 as " "
+state 8 as " "
+state 9 as " "
+state 10 as " "
+state 11 as " "
+state 12 as " "
 state 13 as " "
 
 
@@ -70,18 +73,18 @@ note on link
 end note
 
 'Variation path
-9 --> 13
+9 -[#red]-> 13
 note on link
     <b>User requests to</b>
     * cancel
 end note
-11 --> 13
+11 -[#red]-> 13
 note on link
     <b>User requests to</b>
     * cancel
 end note
 
-13 --> [*]
+13 -[#red]-> [*]
 note on link
 <b>System shows</b>
 * prioritization cancelled

--- a/documentation/usecasesview/specifications/usecases/UpdateUseCase.puml
+++ b/documentation/usecasesview/specifications/usecases/UpdateUseCase.puml
@@ -1,6 +1,9 @@
 @startuml
-skinparam NoteBackgroundColor #whiteSmoke
-
+    skinparam {
+        NoteBackgroundColor #whiteSmoke
+        ArrowColor #green
+        NoteBorderColor #green
+    }
 
 'Initial/end states
 state init as "USE_CASE_MANAGEMENT"
@@ -75,19 +78,19 @@ state UpdateUseCase {
            end note
 
     'variation path
-    editedUseCase --> errorValidation
+    editedUseCase -[#red]-> errorValidation
         note on link
         [ length(useCaseName) out of 5,25 ]
         end note
 
-    errorValidation --> selectedUseCase
+    errorValidation -[#red]-> selectedUseCase
             note on link
             <b>System shows</b>
             * The name length is not correct
             end note
 
     'variation path
-    requireToConfirm --> savedUseCase
+    requireToConfirm -[#red]-> savedUseCase
     note on link
           <b>User</b> cancel
     end note


### PR DESCRIPTION
añado skinParams, para remarcar el successfull flow, en vez de pintar los nodos en verde pintamos las flechas en verde,de modo que si es un camino de canceler o fallo de validacion la flecha se muestra en rojo. Queda mas claro de un vistazo cual es el camino principal